### PR TITLE
Fix results initialization race condition

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -91,7 +91,7 @@ export class Runner extends EventEmitter {
   }
 
   render() {
-    let results = this._currentResults;
+    let results = this._currentResults || [];
     let filters = this.env.filters.map(filter => {
       let negated = filter.indexOf('!') === 0;
       let value = negated ? filter.slice(1) : filter;


### PR DESCRIPTION
Traceback was:

```
TypeError: Cannot read property 'length' of undefined
    at Runner.render (/Users/me/somewhere/node_modules/glow/dist/legacy/Runner.js:306:17)
    at Env.<anonymous> (/Users/me/somewhere/node_modules/glow/dist/legacy/Runner.js:101:24)
    at emitOne (events.js:96:13)
    at Env.emit (events.js:188:7)
    at Env.setFilters (/Users/me/somewhere/node_modules/glow/dist/legacy/Env.js:72:10)
    at Screen.<anonymous> (/Users/me/somewhere/node_modules/glow/dist/legacy/Interface.js:156:17)
    at Screen.EventEmitter._emit (/Users/me/somewhere/node_modules/blessed/lib/events.js:94:20)
    at Screen.EventEmitter.emit (/Users/me/somewhere/node_modules/blessed/lib/events.js:114:17)
    at Program.<anonymous> (/Users/me/somewhere/node_modules/blessed/lib/widgets/screen.js:592:12)
    at emitTwo (events.js:106:13)
```

Note that I'm on flow `0.53.1` (sadness, I know), which isn't supported. I only see this when running `glow --watch` some of the time, but didn't take the time to debug extensively. 

Because I didn't find a minimal repro case, I couldn't come up with a good test for this, but I figured the basic null check couldn't hurt. 