### PR TITLE
Gracefully handle flow exiting with an error

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -88,7 +88,9 @@ export default async function main(cwd: string, argv: Array<string>) {
     debug
   });
 
-  if (status.errors.length !== 0) {
+  if (status.errors && status.errors.length !== 0) {
     process.exit(1);
+  } else if (status.exit) {
+    process.exit(status.exit.code);
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -93,13 +93,20 @@ export type FlowStatusError = {
   extra?: Array<FlowExtra>
 };
 
+export type FlowStatusExit = {
+  code: number,
+  reason: string,
+  msg: string
+};
+
 export type FlowStatus = {
   flowVersion: string,
-  errors: Array<FlowStatusError>
+  errors?: Array<FlowStatusError>,
+  exit?: FlowStatusExit
 };
 
 export type GlowResult = {
-  error: FlowStatusError,
+  error?: FlowStatusError,
   message: string
 };
 


### PR DESCRIPTION
Currently if you have a bad `.flowconfig` file (for example) then flow will exit with an error message not results, this causes Glow to fail.

This change allows Glow to handle Flow error messages. I've changed the `FlowStatus` type to accomodate `FlowStatusExit`, but I'm not sure if it's done in an ideal way - possibly it should be a union type.

Another edge case might be where flow returns errors and also an exit code - not sure if that's possible?