### PR TITLE
show flow errors as info instead of success

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -150,7 +150,7 @@ export class Runner extends EventEmitter {
       );
     }
 
-    this.env.logger.success(message, { status: true });
+    this.env.logger.info(message, { status: true });
 
     if (this.env.interface) {
       this.env.interface.setResults(filteredResults);


### PR DESCRIPTION
updated to have *Found [n] errors.* as info instead of success. 🙂 

Before (currently):

![image](https://user-images.githubusercontent.com/9667784/36639315-6ba62f66-1a5e-11e8-87a4-99ed01bc0fb6.png)


After (with this change):

![image](https://user-images.githubusercontent.com/9667784/36639313-3bd2b48a-1a5e-11e8-9f84-1a28208efce3.png)
