### PR TITLE
Print error count after logging errors

### DIFF
--- a/src/Runner.js
+++ b/src/Runner.js
@@ -150,8 +150,6 @@ export class Runner extends EventEmitter {
       );
     }
 
-    this.env.logger.success(message, { status: true });
-
     if (this.env.interface) {
       this.env.interface.setResults(filteredResults);
     } else {
@@ -163,5 +161,7 @@ export class Runner extends EventEmitter {
       }
       this.env.logger.line();
     }
+    
+    this.env.logger.success(message, { status: true });
   }
 }


### PR DESCRIPTION
This PR makes the error count print at the end of the logged output, like running `flow` does. This prevents having to scroll all the way to the top of a possibly long list of errors when you might only want to see the error count.

<img width="520" alt="screen shot 2018-03-09 at 10 20 18 am" src="https://user-images.githubusercontent.com/12901172/37214608-89f8dfee-2383-11e8-9bb1-b350112d3b5f.png">
