### PR TITLE
Allow more flow versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "util.promisify": "^1.0.0"
   },
   "peerDependencies": {
-    "flow-bin": "^0.63.1"
+    "flow-bin": ">=0.63.1"
   },
   "devDependencies": {
     "ava": "^0.24.0",


### PR DESCRIPTION
Currently getting warnings when using glow together with new versions of flow, even though it works perfectly well. This should fix that